### PR TITLE
AND-193 : Fix error plugin (for Elysia 1.3.1...) add header content type json

### DIFF
--- a/source/elysia/error.ts
+++ b/source/elysia/error.ts
@@ -30,6 +30,7 @@ export const errorPlugin = new Elysia({
         BasaltLoggerError
     })
     .onError(({ code, error, set }) => {
+        set.headers['content-type'] = 'application/json; charset=utf-8';
         switch (code) {
             case 'CoreError':
             case 'BasaltHelperError':


### PR DESCRIPTION
Updated the error handling to set the content-type header to 'application/json; charset=utf-8' for consistent error responses.
